### PR TITLE
Allow Meta mixins

### DIFF
--- a/iommi/declarative/with_meta.py
+++ b/iommi/declarative/with_meta.py
@@ -40,7 +40,7 @@ def get_meta(cls):
     merged_attributes = Namespace()
     for class_ in reversed(cls.mro()):
         if hasattr(class_, 'Meta'):
-            for key in class_.Meta.__dict__:
+            for key in dir(class_.Meta):
                 if not key.startswith('__'):
                     value = getattr(class_.Meta, key)
                     merged_attributes.setitem_path(key, value)


### PR DESCRIPTION
this small change allows Meta mixins, I talked about this on discord in #beginner (2023-08-04)
`dir` might be a bit slower than `__dict__` since it bubbles though mro, but I don't think it runs often enough to be even noticeable

My usecase is: I have 5 different tables and 6 different forms for the same model based on user "role", they differ too much to have one class but still share some properties. I use inheritance now, but I think Meta mixins would make it much cleaner

@jlubcke should check this for potential problems